### PR TITLE
Reject integers with lengths not between 8 and 14.

### DIFF
--- a/lib/barcoder.js
+++ b/lib/barcoder.js
@@ -17,7 +17,7 @@
    * Config
    */
 
-  var validationRegex = /^\d{6,18}$/;
+  var validationRegex = /^\d{8,14}$/;
 
   /**
    * Converts strings to intergers
@@ -91,7 +91,7 @@
 
     var self = this;
 
-    if ( validationRegex.exec( barcode ) === null ) {
+    if ( validationRegex.exec( parseInt(barcode).toString() ) === null ) {
       return false;
     }
 


### PR DESCRIPTION
Since we only want to verify GTIN8 through GTIN14: http://www.gs1.org/how-calculate-check-digit-manually.
Otherwise it'd validate invalid gtins like 00000000405713 or 405713.